### PR TITLE
add examples to send and receive lsl markers

### DIFF
--- a/lab_streaming_layer/README.md
+++ b/lab_streaming_layer/README.md
@@ -1,0 +1,7 @@
+# LabStreamingLayer Examples
+
+There are two python scripts in this folder to demonstrate sending or receiving LSL markers:
+
+* `lsl_marker_receive.py`: This demonstrates how you can receive LSL markers and forward them via websocket to your labvanced study. To test this you can checkout the following Labvanced template study: [https://www.labvanced.com/page/library/53230](https://www.labvanced.com/page/library/53230).
+
+* `lsl_marker_send.py`: This demonstrates how you can send LSL markers from your labvanced study. To test this you can checkout the following Labvanced template study: [https://www.labvanced.com/page/library/53231](https://www.labvanced.com/page/library/53231).

--- a/lab_streaming_layer/lsl_marker_receive.py
+++ b/lab_streaming_layer/lsl_marker_receive.py
@@ -1,0 +1,43 @@
+"""Example program to show how to read a multi-channel time series from LSL."""
+
+from pylsl import StreamInlet, resolve_stream, LostError
+import asyncio
+import json
+import websockets
+
+
+IP_ADDRESS = '0.0.0.0'
+WEBSOCKET_PORT = 8081
+
+
+async def on_connect(websocket, path):
+    print("websocket connection established")
+
+    # first resolve a Markers stream on the network
+    print("looking for a Markers stream...")
+    streams = resolve_stream("name", "my_stream_1")
+
+    # create a new inlet to read from the stream
+    inlet = StreamInlet(streams[0])
+
+    while True:
+        try:
+            sample, timestamp = inlet.pull_sample(timeout=1.0)
+            if timestamp is not None:
+                print(timestamp, sample)
+                # forward lsl marker to Labvanced:
+                await websocket.send(json.dumps({'msg': 'lsl_marker', 'value': sample[0]}))
+
+        except LostError:
+            print("Lost connection to lsl stream. Exiting...")
+            break
+
+
+def main():
+    # Make sure that the IP address and port match with the Labvanced study settings.
+    asyncio.get_event_loop().run_until_complete(websockets.serve(on_connect, IP_ADDRESS, WEBSOCKET_PORT))
+    asyncio.get_event_loop().run_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/lab_streaming_layer/lsl_marker_send.py
+++ b/lab_streaming_layer/lsl_marker_send.py
@@ -1,0 +1,55 @@
+"""Example program to demonstrate how to forward string-valued markers from labvanced into LSL."""
+
+import asyncio
+import json
+import websockets
+
+from pylsl import StreamInfo, StreamOutlet
+
+from pylsl.pylsl import cf_string
+
+
+IP_ADDRESS = '0.0.0.0'
+WEBSOCKET_PORT = 8081
+
+
+async def on_connect(websocket, path):
+    print("websocket connection established")
+
+    # first create a new stream info (here we set the name to MyMarkerStream,
+    # the content-type to Markers, 1 channel, irregular sampling rate,
+    # and string-valued data) The last value would be the locally unique
+    # identifier for the stream as far as available, e.g.
+    # program-scriptname-subjectnumber (you could also omit it but interrupted
+    # connections wouldn't auto-recover). The important part is that the
+    # content-type is set to 'Markers', because then other programs will know how
+    #  to interpret the content
+    info = StreamInfo(name='labvanced_stream_1', type='Markers', channel_count=1, nominal_srate=0, channel_format=cf_string, source_id='myuidw43536')
+
+    # next make an outlet
+    outlet = StreamOutlet(info)
+
+    try:
+        async for message in websocket:
+            data = json.loads(message)
+            # data has two fields 'msg' and 'data'. msg is the trigger / message, value is the variable value, both
+            # defined in the 'send external trigger action' in your Labvanced experiment.
+            received_value = data['value']
+            received_msg = data['msg']
+            if received_msg == 'lsl_marker':
+                print("msg = {}, received_value = {}".format(received_msg, received_value))
+                outlet.push_sample([received_value])
+            else:
+                print("unsupported event: {}".format(data))
+    finally:
+        print("connection lost")
+
+
+def main():
+    # Make sure that the IP address and port match with the Labvanced study settings.
+    asyncio.get_event_loop().run_until_complete(websockets.serve(on_connect, IP_ADDRESS, WEBSOCKET_PORT))
+    asyncio.get_event_loop().run_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/lab_streaming_layer/requirements.txt
+++ b/lab_streaming_layer/requirements.txt
@@ -1,0 +1,4 @@
+asyncio
+jsons
+websockets
+pylsl


### PR DESCRIPTION
Just two simple example python scripts that demonstrate how you can forward lsl markers to and from labvanced studies.